### PR TITLE
Patch gdm

### DIFF
--- a/R/GDM.R
+++ b/R/GDM.R
@@ -234,18 +234,17 @@ gdm_run <- function(gendist, coords, env, model = "full", sig = 0.05, nperm = 50
 #' @param gdmData data formatted using GDM package
 #' @param sig sig level for determining variable significance
 #' @param nperm number of permutations to run for variable testing
-#' @param predSelect whether to perform variable selection (defaults to TRUE); if set to FALSE, the function will return p-values for all variables
 #'
 #' @family GDM functions
 #'
 #' @export
-gdm_var_sel <- function(gdmData, sig = 0.05, nperm = 10, predSelect = TRUE) {
+gdm_var_sel <- function(gdmData, sig = 0.05, nperm = 10) {
   # Check var importance/significance (THIS STEP CAN TAKE A WHILE)
   vars <- gdm::gdm.varImp(gdmData,
     geo = FALSE,
     splines = NULL,
     nPerm = nperm,
-    predSelect = predSelect
+    predSelect = TRUE
   )
 
   # Get p-values from variable selection model

--- a/R/GDM.R
+++ b/R/GDM.R
@@ -165,7 +165,7 @@ gdm_run <- function(gendist, coords, env, model = "full", sig = 0.05, nperm = 50
 
   # If model = "best", conduct variable selection procedure
   if (model == "best") {
-    # Add distance matrix separately
+    # Add Euclidean distance matrix separately (otherwise geography will not be evaluated for removal)
     if (geodist_type == "Euclidean") {
       geodist <- geo_dist(coords)
       gdmDist <- cbind(site, geodist)
@@ -204,11 +204,11 @@ gdm_run <- function(gendist, coords, env, model = "full", sig = 0.05, nperm = 50
     gdmPred_final <- gdmPred[, c("site", "x", "y", finalvars)]
     gdmData_final <- gdm::formatsitepair(gdmGen, bioFormat = 3, XColumn = "x", YColumn = "y", siteColumn = "site", predData = gdmPred_final)
 
-    # If geo = TRUE and geodist_type is resistance or topographic, add the distance matrix 
+    # If geo = TRUE and geodist_type is resistance or topographic, add the gdmDist matrix 
     if (geodist_type == "resistance" | geodist_type == "topographic"){
       if (geo){
         gdmData_final <- gdm::formatsitepair(gdmData_final, 4, predData = gdmPred_final, siteColumn = "site", distPreds = list(geodist = as.matrix(gdmDist)))
-        # Set geo to FALSE (since it's already included, we don't want to also include euclidean distance)
+        # Set geo to FALSE (since it's already included, we don't want to also include Euclidean distances)
         geo <- FALSE
       } 
     } 


### PR DESCRIPTION
Bugs in the GDM function related to topographic/resistance distances and variable selection:
1. If topographic/resistance distances were used, an error would get returned because gdmData was introduced before it was defined. -> fixed by putting the line to create gdmData in the correct location before the introduction of the distance matrices
2. If topographic/resistance distances were used and variable selection was performed (i.e., model = "best") and the distances were found to be significant, the distance matrices would not be included because the code was written assuming Euclidean distances so the way the model was run was just setting the geo argument to TRUE if geo was significant (which runs the gdm model with euclidean geographic distances) -> this was fixed such that if geo was significant the custom distance matrix was added and geo (the GDM argument) was set  to FALSE
3. There was an argument in gdm_run() called distPreds that had no function (I think the original intention was to allow for the inclusion of additional custom distance matrices but right now it is doing nothing) -> removed this arg