### PR TITLE
Add SNP names to rdadapt row names

### DIFF
--- a/R/RDA.R
+++ b/R/RDA.R
@@ -280,14 +280,14 @@ rda_getoutliers <- function(mod, naxes = "all", outlier_method = "p", p_adj = "f
 p_outlier_method <- function(mod, naxes, sig = 0.05, p_adj = "fdr") {
   rdadapt_env <- rdadapt(mod, naxes)
 
-  # p-value threshold after p-value adjustment (different from Capblancq & Forester 2021)
-  pvalues <- p.adjust(rdadapt_env$p.values, method = p_adj)
-
   # Get SNP names
   snp_names <- rownames(vegan::scores(mod, choices = naxes, display = "species"))
 
-  # Restore SNP names
-  names(pvalues) <- snp_names
+  # Restore SNP names to rdadapt
+  row.names(rdadapt_env) <- snp_names
+  
+  # p-value threshold after p-value adjustment (different from Capblancq & Forester 2021)
+  pvalues <- p.adjust(rdadapt_env$p.values, method = p_adj)
 
   # Identifying the SNPs that are below the p-value threshold
   rda_snps <- snp_names[which(pvalues < sig)]

--- a/vignettes/RDA_vignette.Rmd
+++ b/vignettes/RDA_vignette.Rmd
@@ -258,13 +258,11 @@ length(rda_sig_p$rda_snps)
 As mentioned above, we could also identify outliers based on q-values. To do so, we can extract the q-values from the resulting object from `rda_getoutliers()`.
 
 ```{r q-values}
-# Extract SNP names; choices is number of axes
-snp_names <- rownames(scores(mod_best, choices = 2, display = "species"))
-
 # Identify outliers that have q-values < 0.1
 q_sig <-
   rda_sig_p$rdadapt %>%
-  mutate(snp_names = snp_names) %>%
+  # Make SNP names column from row names
+  mutate(snp_names = row.names(.)) %>%
   filter(q.values <= 0.1)
 
 # How many outlier SNPs were detected?


### PR DESCRIPTION
I think just adding the SNP names as the row names of rdadapt is cleaner than having the `snp_names <- rownames(scores(mod_best, choices = 2, display = "species"))` in the vignette. It would be even better if we just added snp_names as a column to rdadapt, but I would be worried about messing up someone's downstream code.