### PR TITLE
Change default of mask plotting to RGB = FALSE

### DIFF
--- a/R/masks.R
+++ b/R/masks.R
@@ -193,7 +193,7 @@ chull_mask <- function(coords, envlayers, buffer_width = NULL) {
 #' @export
 #'
 #' @seealso \code{\link{extrap_mask}}
-plot_extrap_mask <- function(map_r, map_mask, RGB_cols = TRUE, mask_col = rgb(0, 0, 0, alpha = 0.9)) {
+plot_extrap_mask <- function(map_r, map_mask, RGB_cols = FALSE, mask_col = rgb(0, 0, 0, alpha = 0.9)) {
   if (!inherits(map_r, "SpatRaster")) map_r <- terra::rast(map_r)
   if (!inherits(map_mask, "SpatRaster")) map_mask <- terra::rast(map_mask)
 


### PR DESCRIPTION
I don't think it makes sense to assume that users will want to make an RGB plot for their mask plot. Tbh I think we should probably just remove this function all together and show people how to make the plots themselves in the vignette. Open to suggestions.