### PR TITLE
Patch gdm dissimilarity plotting

### DIFF
--- a/R/GDM.R
+++ b/R/GDM.R
@@ -505,8 +505,7 @@ gdm_plot_diss <- function(gdm_model) {
   # Get data for overlaid lines
   overlayX_ecol <- seq(from = min(dat$ecological), to = max(dat$ecological), length = datL)
   overlayY_ecol <- 1 - exp(-overlayX_ecol)
-  overlayX_pred <- seq(from = min(dat$predicted), to = max(dat$predicted), length = datL)
-  overlayY_pred <- 1 - exp(-overlayX_pred)
+  overlayY_pred <- overlayX_pred <- seq(from = min(dat$predicted), to = max(dat$predicted), length = datL)
 
   plot_ecol <-
     ggplot2::ggplot(dat) +

--- a/R/GDM.R
+++ b/R/GDM.R
@@ -511,7 +511,7 @@ gdm_plot_diss <- function(gdm_model) {
     ggplot2::ggplot(dat) +
     ggplot2::geom_point(ggplot2::aes(x = ecological, y = observed), color = "darkgrey", alpha = 0.6, size = 2) +
     ggplot2::theme_bw() +
-    ggplot2::scale_y_continuous(limits = c(0, 1), expand = c(0, 0)) +
+    ggplot2::scale_y_continuous(expand = c(0, 0)) +
     ggplot2::xlab("Predicted ecological distance") +
     ggplot2::ylab("Observed compositional dissimilarity") +
     ggplot2::geom_line(ggplot2::aes(x = overlayX_ecol, y = overlayY_ecol), size = 1)
@@ -520,7 +520,7 @@ gdm_plot_diss <- function(gdm_model) {
     ggplot2::ggplot(dat) +
     ggplot2::geom_point(ggplot2::aes(x = predicted, y = observed), color = "darkgrey", alpha = 0.6, size = 2) +
     ggplot2::theme_bw() +
-    ggplot2::scale_y_continuous(limits = c(0, 1), expand = c(0, 0)) +
+    ggplot2::scale_y_continuous(expand = c(0, 0)) +
     ggplot2::xlab("Predicted compositional dissimilarity") +
     ggplot2::ylab("Observed compositional dissimilarity") +
     ggplot2::geom_line(ggplot2::aes(x = overlayX_pred, y = overlayY_pred), size = 1)


### PR DESCRIPTION
This PR corrects two issues: 

1. MAJOR: incorrect y values provided for plotting the line on the observed vs predicted dissimilarity plot. The y (observed compositional dissim) values for the line should be the same as the x since it is just observed vs predicted. The 1 - exp() is only needed for transforming for the ecological distances vs dissimilarity plot. See the original GDM code: https://github.com/fitzLab-AL/gdm/blob/fc48229f241f96976ba922397bcd2f83e9140b79/R/gdm.plot.R#L118

2. MINOR: The y values will only be bound between 0 and 1 if the genetic distances range from 0 to 1, which is not always the case (i.e., we enforce that all values are in that range, but you could have genetic distances from 0 to 0.1 in which case this plot will be hard to read/squished)