### PR TITLE
update docs for gen_dist() function and gen_dist vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Description: What the package does (one paragraph).
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Suggests: 
     knitr,
     rmarkdown,

--- a/R/Gen_dist.R
+++ b/R/Gen_dist.R
@@ -2,7 +2,7 @@
 #'
 #' @param gen path to vcf file, a `vcfR` type object, or a dosage matrix
 #' @param dist_type the type of genetic distance to calculate (options: `"euclidean"` (default), `"bray_curtis"`, `"dps"` for proportion of shared alleles (requires vcf), `"plink"`, or `"pc"` for PC-based)
-#' @param plink_file if `"plink"` dist_type is used, path to plink distance file (typically ".dist"; required only for calculating plink distance)
+#' @param plink_file if `"plink"` dist_type is used, path to plink distance file (typically ".dist"; required only for calculating plink distance). File must be a **square** distance matrix.
 #' @param plink_id_file if `"plink"` dist_type is used, path to plink id file (typically ".dist.id"; required only for calculating plink distance)
 #' @param npc_selection if `dist_type = "pc"`, how to perform K selection (options: `"auto"` for automatic selection based on significant eigenvalues from Tracy-Widom test (default), or `"manual"` to examine PC screeplot and enter no. PCs into console)
 #' @param criticalpoint if `dist_type = "pc"` used with `npc_selection = "auto"`, the critical point for the significance threshold for the Tracy-Widom test within the PCA (defaults to 2.0234 which corresponds to an alpha of 0.01)

--- a/man/gen_dist.Rd
+++ b/man/gen_dist.Rd
@@ -18,7 +18,7 @@ gen_dist(
 
 \item{dist_type}{the type of genetic distance to calculate (options: \code{"euclidean"} (default), \code{"bray_curtis"}, \code{"dps"} for proportion of shared alleles (requires vcf), \code{"plink"}, or \code{"pc"} for PC-based)}
 
-\item{plink_file}{if \code{"plink"} dist_type is used, path to plink distance file (typically ".dist"; required only for calculating plink distance)}
+\item{plink_file}{if \code{"plink"} dist_type is used, path to plink distance file (typically ".dist"; required only for calculating plink distance). File must be a \strong{square} distance matrix.}
 
 \item{plink_id_file}{if \code{"plink"} dist_type is used, path to plink id file (typically ".dist.id"; required only for calculating plink distance)}
 

--- a/vignettes/gen_dist_vignette.Rmd
+++ b/vignettes/gen_dist_vignette.Rmd
@@ -39,7 +39,7 @@ For several landscape genomics analyses, a pairwise genetic distance matrix is r
 
 4.  PC-based distance (the `"pc"` argument), which uses the `prcomp()` function within the [stats](https://stat.ethz.ch/R-manual/R-devel/library/stats/html/00Index.html) package and selects the number of PCs using a Tracy-Widom test (if `npc_selection = "auto"`; also requires specifying `criticalpoint` [see below for details]) or user-inputted PCs based on examining a screeplot and manually entering a value into the console (if `npc_selection = "manual"`)
 
-5.  Processing distances generated using Plink (the `"plink"` argument). This type of distance requires providing paths to two plink output files (the distance file, `plink_file`, and the ID file, `plink_id_file`)
+5.  Processing distances generated using Plink (the `"plink"` argument). This type of distance requires providing paths to two plink output files (the distance file, `plink_file`, and the ID file, `plink_id_file`); the distance file **must** be a square (i.e., symmetric) distance matrix
 
 A good place to start to understand these metrics is [Shirk et al., 2017](https://onlinelibrary.wiley.com/doi/abs/10.1111/1755-0998.12684), who tested a number of different genetic distance metrics (including most of the above) and compared results for use in landscape genetics analyses.
 
@@ -66,7 +66,7 @@ euc_dists <- gen_dist(liz_vcf, dist_type = "euclidean")
 euc_dists[1:5, 1:5]
 ```
 
-Now, let's process Plink distances:
+Now, let's process Plink distances, keeping in mind that the provided Plink distance matrix must be square (i.e., symmetric). Refer the Plink documentation for how to generate a square distance matrix.
 
 ```{r plink dists}
 plink_dists <- gen_dist(plink_file = system.file("extdata", "liz_test.dist", package = "algatr"), plink_id_file = system.file("extdata", "liz_test.dist.id", package = "algatr"), dist_type = "plink")
@@ -114,8 +114,8 @@ gen_dist_hm(dps_dists)
 
 ------------------------------------------------------------------------
 
-|                       | Citation/URL                                                                                                                                                                 | Details                                                                                                                |
-|-------------------|-----------------------------|-------------------------|
-| Associated code       | [Goslee & Urban 2007](https://cran.r-project.org/web/packages/ecodist/index.html)                                                                                            | algatr's calculation of Euclidean and Bray-Curtis distances using the `distance()` function within the ecodist package |
-| Associated code       | [Jombart 2008](https://academic.oup.com/bioinformatics/article/24/11/1403/191127); [Jombart & Ahmed 2011](https://academic.oup.com/bioinformatics/article/27/21/3070/218892) | algatr's calculation of proportion of shared alleles using the `propShared()` function within the adegenet package     |
-| Associated literature | [Shirk et al., 2017](https://onlinelibrary.wiley.com/doi/abs/10.1111/1755-0998.12684)                                                                                        | Paper testing a number of different genetic distance metrics (including those used by algatr) for landscape genomics   |
+|   | Citation/URL | Details |
+|-------------------|----------------------------|-------------------------|
+| Associated code | [Goslee & Urban 2007](https://cran.r-project.org/web/packages/ecodist/index.html) | algatr's calculation of Euclidean and Bray-Curtis distances using the `distance()` function within the ecodist package |
+| Associated code | [Jombart 2008](https://academic.oup.com/bioinformatics/article/24/11/1403/191127); [Jombart & Ahmed 2011](https://academic.oup.com/bioinformatics/article/27/21/3070/218892) | algatr's calculation of proportion of shared alleles using the `propShared()` function within the adegenet package |
+| Associated literature | [Shirk et al., 2017](https://onlinelibrary.wiley.com/doi/abs/10.1111/1755-0998.12684) | Paper testing a number of different genetic distance metrics (including those used by algatr) for landscape genomics |


### PR DESCRIPTION
Updated the `gen_dist()` function description to clarify that a square distance matrix must be provided to the function if using the Plink inputs. Also added these details into the gen_dist vignette.