### PR TITLE
major fix to lfmm_run

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Description: What the package does (one paragraph).
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Suggests: 
     knitr,
     rmarkdown,

--- a/R/LFMM.R
+++ b/R/LFMM.R
@@ -146,7 +146,7 @@ lfmm_run <- function(gen, env, K, lfmm_method = "ridge", p_adj = "fdr", sig = 0.
   result_df <- lfmm_df(lfmm_test_result)
 
   # Subset out candidate SNPs
-  lfmm_snps <- result_df %>% dplyr::filter(adjusted.pvalue < 0.05)
+  lfmm_snps <- result_df %>% dplyr::filter(adjusted.pvalue < sig)
 
   return(list(lfmm_snps = lfmm_snps, df = result_df, model = lfmm_mod, lfmm_test_result = lfmm_test_result, K = K))
 }


### PR DESCRIPTION
Major bug in `lfmm_run()` in which significance threshold for outlier detection was hard-coded as 0.05 instead of `sig` argument.